### PR TITLE
new: Add initial support for reading cgroup information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import atoparser
 
 with open(file, 'rb') as raw_file:
     header = atoparser.get_header(raw_file)
-    for record, sstat, tstat in atoparser.generate_statistics(raw_file, header):
+    for record, sstat, tstats, cgroups in atoparser.generate_statistics(raw_file, header):
         total_cycles = record.interval * sstat.cpu.nrcpu * header.hertz
         usage = 1 - sstat.cpu.all.itime / total_cycles
         print(f'CPU usage was {usage:.02%}')

--- a/atoparser/__init__.py
+++ b/atoparser/__init__.py
@@ -1,10 +1,13 @@
 """Libraries for reading Atop raw data files."""
 
+from atoparser.utils import CGChainer
+from atoparser.utils import CStat
 from atoparser.utils import Header
 from atoparser.utils import Record
 from atoparser.utils import SStat
 from atoparser.utils import TStat
 from atoparser.utils import generate_statistics
+from atoparser.utils import get_cstat
 from atoparser.utils import get_header
 from atoparser.utils import get_record
 from atoparser.utils import get_sstat

--- a/atoparser/structs/atop_1_26.py
+++ b/atoparser/structs/atop_1_26.py
@@ -636,7 +636,7 @@ class PStat(ctypes.Structure):
     ]
 
 
-# Add TStat aliases for forwards compatibility. TStat and PStat are the same base stats, but renamed in later versions.
+# Add TStat alias for forwards compatibility. TStat and PStat are the same base stats, but renamed in later versions.
 TStat = PStat
 
 
@@ -671,3 +671,7 @@ class Header(ctypes.Structure, HeaderMixin):
     Record = Record
     SStat = SStat
     PStat = PStat
+    # Add TStat alias for forwards compatibility. TStat and PStat are the same base stats, but renamed in later versions.
+    TStat = PStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_10.py
+++ b/atoparser/structs/atop_2_10.py
@@ -458,3 +458,5 @@ class Header(atop_2_8.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_3.py
+++ b/atoparser/structs/atop_2_3.py
@@ -579,3 +579,5 @@ class Header(ctypes.Structure, HeaderMixin):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_4.py
+++ b/atoparser/structs/atop_2_4.py
@@ -366,3 +366,5 @@ class Header(atop_2_3.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_5.py
+++ b/atoparser/structs/atop_2_5.py
@@ -173,3 +173,5 @@ class Header(atop_2_3.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_6.py
+++ b/atoparser/structs/atop_2_6.py
@@ -331,3 +331,5 @@ class Header(atop_2_3.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_7.py
+++ b/atoparser/structs/atop_2_7.py
@@ -399,3 +399,5 @@ class Header(atop_2_3.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_8.py
+++ b/atoparser/structs/atop_2_8.py
@@ -612,3 +612,5 @@ class Header(ctypes.Structure, HeaderMixin):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/atop_2_9.py
+++ b/atoparser/structs/atop_2_9.py
@@ -241,3 +241,5 @@ class Header(atop_2_8.Header):
     Record = Record
     SStat = SStat
     TStat = TStat
+    CStat = None
+    CGChainer = None

--- a/atoparser/structs/shared.py
+++ b/atoparser/structs/shared.py
@@ -20,7 +20,6 @@ time_t = ctypes.c_long
 count_t = ctypes.c_longlong
 
 # Definitions from sys/types.h
-c_int32_t = ctypes.c_int32
 off_t = ctypes.c_long
 pid_t = ctypes.c_int
 
@@ -32,7 +31,12 @@ class HeaderMixin:
         supported_version: The version of Atop that this header is compatible with as <major.<minor>.
     """
 
-    supported_version = None
+    supported_version: str
+    Record: ctypes.Structure
+    SStat: ctypes.Structure
+    TStat: ctypes.Structure
+    CStat: ctypes.Structure
+    CGChainer: ctypes.Structure
 
     def check_compatibility(self) -> None:
         """Verify if the loaded values are compatible with this header version.
@@ -48,7 +52,9 @@ class HeaderMixin:
         if self.major_version >= 2 and self.minor_version >= 3:
             sizes.append(("TStat", self.tstatlen, ctypes.sizeof(self.TStat)))
         else:
-            sizes.append(("PStat", self.pstatlen, ctypes.sizeof(self.PStat)))
+            sizes.append(("PStat", self.pstatlen, ctypes.sizeof(self.TStat)))
+        if self.major_version >= 2 and self.minor_version >= 11:
+            sizes.append(("CStat", self.cstatlen, ctypes.sizeof(self.CStat)))
         if any(size[1] != size[2] for size in sizes):
             raise ValueError(
                 f"File has incompatible Atop format. Struct length evaluations (type, found, expected): {sizes}"


### PR DESCRIPTION
This introduces a breaking change to generate_statistics. Moving forward, generate_statistics will now generate 4 items. The fourth group is CStat/CGroup information, similar to TStat.

## Contributor Checklist

Please confirm the following:

- [x] I have run tests locally, and they all pass.
- [x] I have added or extended tests, to cover any new features or changes included in this PR.
- [x] I have added or updated documentation, to cover any new features or changes included in this PR.
- [x] I have followed the [Contributing Guide](/pyranha-labs/atoparser/blob/main/CONTRIBUTING.md) to ensure code quality to the best of my ability.
- [x] I have self-reviewed my PR to ensure the guidelines have been followed to the best of my ability.
